### PR TITLE
Fix migration naming collisions

### DIFF
--- a/db/migrate/20220314190045_community_create_gamification_score_table.rb
+++ b/db/migrate/20220314190045_community_create_gamification_score_table.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateGamificationScoreTable < ActiveRecord::Migration[6.1]
+class CommunityCreateGamificationScoreTable < ActiveRecord::Migration[6.1]
   def change
     create_table :gamification_scores do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20220315172912_community_add_score_to_directory_items.rb
+++ b/db/migrate/20220315172912_community_add_score_to_directory_items.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddScoreToDirectoryItems < ActiveRecord::Migration[6.1]
+class CommunityAddScoreToDirectoryItems < ActiveRecord::Migration[6.1]
   def up
     add_column :directory_items, :gamification_score, :integer, default: 0
   end

--- a/db/migrate/20220324210218_community_create_gamification_leaderboard_table.rb
+++ b/db/migrate/20220324210218_community_create_gamification_leaderboard_table.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class CreateGamificationLeaderboardTable < ActiveRecord::Migration[6.1]
+class CommunityCreateGamificationLeaderboardTable < ActiveRecord::Migration[6.1]
   def change
     create_table :gamification_leaderboards do |t|
       t.string :name, null: false

--- a/db/migrate/20220331203401_community_add_groups_to_leaderboards.rb
+++ b/db/migrate/20220331203401_community_add_groups_to_leaderboards.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddGroupsToLeaderboards < ActiveRecord::Migration[6.1]
+class CommunityAddGroupsToLeaderboards < ActiveRecord::Migration[6.1]
   def change
     add_column :gamification_leaderboards,
                :visible_to_groups_ids,

--- a/db/migrate/20220623182333_community_add_excluded_groups_to_leaderboards.rb
+++ b/db/migrate/20220623182333_community_add_excluded_groups_to_leaderboards.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddExcludedGroupsToLeaderboards < ActiveRecord::Migration[6.1]
+class CommunityAddExcludedGroupsToLeaderboards < ActiveRecord::Migration[6.1]
   def change
     add_column :gamification_leaderboards,
                :excluded_groups_ids,

--- a/db/migrate/20221019171131_community_add_default_period_to_leaderboards.rb
+++ b/db/migrate/20221019171131_community_add_default_period_to_leaderboards.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-class AddDefaultPeriodToLeaderboards < ActiveRecord::Migration[6.1]
+class CommunityAddDefaultPeriodToLeaderboards < ActiveRecord::Migration[6.1]
   def up
     add_column :gamification_leaderboards, :default_period, :integer, default: 0
   end

--- a/db/migrate/20230420185415_community_create_gamification_score_events.rb
+++ b/db/migrate/20230420185415_community_create_gamification_score_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class CreateGamificationScoreEvents < ActiveRecord::Migration[7.0]
+class CommunityCreateGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def change
     create_table :gamification_score_events do |t|
       t.integer :user_id, null: false

--- a/db/migrate/20250102185307_community_add_period_filter_disabled_to_leaderboards.rb
+++ b/db/migrate/20250102185307_community_add_period_filter_disabled_to_leaderboards.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddPeriodFilterDisabledToLeaderboards < ActiveRecord::Migration[7.2]
+class CommunityAddPeriodFilterDisabledToLeaderboards < ActiveRecord::Migration[7.2]
   def change
     add_column :gamification_leaderboards,
                :period_filter_disabled,

--- a/db/migrate/20250103120000_community_add_reason_to_gamification_score_events.rb
+++ b/db/migrate/20250103120000_community_add_reason_to_gamification_score_events.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class AddReasonToGamificationScoreEvents < ActiveRecord::Migration[7.0]
+class CommunityAddReasonToGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def up
     # 1. Add the column as nullable with a default empty string
     add_column :gamification_score_events, :reason, :string, default: "", null: true

--- a/db/migrate/20250630080000_community_update_scores_to_cumulative.rb
+++ b/db/migrate/20250630080000_community_update_scores_to_cumulative.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class UpdateScoresToCumulative < ActiveRecord::Migration[7.0]
+class CommunityUpdateScoresToCumulative < ActiveRecord::Migration[7.0]
   def up
     remove_index :gamification_scores, [:user_id, :date]
 

--- a/db/migrate/20250701000000_community_add_related_fields_to_gamification_score_events.rb
+++ b/db/migrate/20250701000000_community_add_related_fields_to_gamification_score_events.rb
@@ -1,4 +1,4 @@
-class AddRelatedFieldsToGamificationScoreEvents < ActiveRecord::Migration[7.0]
+class CommunityAddRelatedFieldsToGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def change
     add_column :gamification_score_events, :related_id, :text
     add_column :gamification_score_events, :related_type, :text

--- a/db/post_migrate/20250210133038_community_drop_versioned_leaderboard_materialized_views.rb
+++ b/db/post_migrate/20250210133038_community_drop_versioned_leaderboard_materialized_views.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class DropVersionedLeaderboardMaterializedViews < ActiveRecord::Migration[7.2]
+class CommunityDropVersionedLeaderboardMaterializedViews < ActiveRecord::Migration[7.2]
   def up
     versioned_mviews_query = <<~SQL
       SELECT cls.relname


### PR DESCRIPTION
## Summary
- prefix all migration class names with `Community` to avoid collisions with official `discourse-gamification` plugin
- rename migration files with `community_` prefix

## Testing
- `bundle exec rspec spec --format doc --order defined` *(fails: bundler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6879116d2f30832cae8b8907423a5218