### PR TITLE
Ensure migrations skip existing structures

### DIFF
--- a/db/migrate/20220314190901_community_create_gamification_score_table.rb
+++ b/db/migrate/20220314190901_community_create_gamification_score_table.rb
@@ -1,13 +1,18 @@
 # frozen_string_literal: true
 class CommunityCreateGamificationScoreTable < ActiveRecord::Migration[6.1]
   def change
-    create_table :gamification_scores do |t|
-      t.integer :user_id, null: false
-      t.date :date, null: false
-      t.integer :score, null: false
+    unless table_exists?(:gamification_scores)
+      create_table :gamification_scores do |t|
+        t.integer :user_id, null: false
+        t.date :date, null: false
+        t.integer :score, null: false
+      end
     end
 
-    add_index :gamification_scores, %i[user_id date], unique: true
-    add_index :gamification_scores, :date
+    unless index_exists?(:gamification_scores, %i[user_id date])
+      add_index :gamification_scores, %i[user_id date], unique: true
+    end
+
+    add_index :gamification_scores, :date unless index_exists?(:gamification_scores, :date)
   end
 end

--- a/db/migrate/20220315172902_community_add_score_to_directory_items.rb
+++ b/db/migrate/20220315172902_community_add_score_to_directory_items.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 class CommunityAddScoreToDirectoryItems < ActiveRecord::Migration[6.1]
   def up
-    add_column :directory_items, :gamification_score, :integer, default: 0
+    unless column_exists?(:directory_items, :gamification_score)
+      add_column :directory_items, :gamification_score, :integer, default: 0
+    end
   end
 
   def down
-    remove_column :directory_items, :gamification_score
+    remove_column :directory_items, :gamification_score if column_exists?(:directory_items, :gamification_score)
   end
 end

--- a/db/migrate/20220324210903_community_create_gamification_leaderboard_table.rb
+++ b/db/migrate/20220324210903_community_create_gamification_leaderboard_table.rb
@@ -1,15 +1,17 @@
 # frozen_string_literal: true
 class CommunityCreateGamificationLeaderboardTable < ActiveRecord::Migration[6.1]
   def change
-    create_table :gamification_leaderboards do |t|
-      t.string :name, null: false
-      t.date :from_date, null: true
-      t.date :to_date, null: true
-      t.integer :for_category_id, null: true
-      t.integer :created_by_id, null: false
-      t.timestamps
+    unless table_exists?(:gamification_leaderboards)
+      create_table :gamification_leaderboards do |t|
+        t.string :name, null: false
+        t.date :from_date, null: true
+        t.date :to_date, null: true
+        t.integer :for_category_id, null: true
+        t.integer :created_by_id, null: false
+        t.timestamps
+      end
     end
 
-    add_index :gamification_leaderboards, [:name], unique: true
+    add_index :gamification_leaderboards, [:name], unique: true unless index_exists?(:gamification_leaderboards, [:name])
   end
 end

--- a/db/migrate/20220331203904_community_add_groups_to_leaderboards.rb
+++ b/db/migrate/20220331203904_community_add_groups_to_leaderboards.rb
@@ -1,17 +1,22 @@
 # frozen_string_literal: true
 class CommunityAddGroupsToLeaderboards < ActiveRecord::Migration[6.1]
   def change
-    add_column :gamification_leaderboards,
-               :visible_to_groups_ids,
-               :integer,
-               array: true,
-               null: false,
-               default: []
-    add_column :gamification_leaderboards,
-               :included_groups_ids,
-               :integer,
-               array: true,
-               null: false,
-               default: []
+    unless column_exists?(:gamification_leaderboards, :visible_to_groups_ids)
+      add_column :gamification_leaderboards,
+                 :visible_to_groups_ids,
+                 :integer,
+                 array: true,
+                 null: false,
+                 default: []
+    end
+
+    unless column_exists?(:gamification_leaderboards, :included_groups_ids)
+      add_column :gamification_leaderboards,
+                 :included_groups_ids,
+                 :integer,
+                 array: true,
+                 null: false,
+                 default: []
+    end
   end
 end

--- a/db/migrate/20220623182905_community_add_excluded_groups_to_leaderboards.rb
+++ b/db/migrate/20220623182905_community_add_excluded_groups_to_leaderboards.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 class CommunityAddExcludedGroupsToLeaderboards < ActiveRecord::Migration[6.1]
   def change
-    add_column :gamification_leaderboards,
-               :excluded_groups_ids,
-               :integer,
-               array: true,
-               null: false,
-               default: []
+    unless column_exists?(:gamification_leaderboards, :excluded_groups_ids)
+      add_column :gamification_leaderboards,
+                 :excluded_groups_ids,
+                 :integer,
+                 array: true,
+                 null: false,
+                 default: []
+    end
   end
 end

--- a/db/migrate/20221019171906_community_add_default_period_to_leaderboards.rb
+++ b/db/migrate/20221019171906_community_add_default_period_to_leaderboards.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 class CommunityAddDefaultPeriodToLeaderboards < ActiveRecord::Migration[6.1]
   def up
-    add_column :gamification_leaderboards, :default_period, :integer, default: 0
+    unless column_exists?(:gamification_leaderboards, :default_period)
+      add_column :gamification_leaderboards, :default_period, :integer, default: 0
+    end
   end
 
   def down
-    remove_column :gamification_leaderboards, :default_period
+    remove_column :gamification_leaderboards, :default_period if column_exists?(:gamification_leaderboards, :default_period)
   end
 end

--- a/db/migrate/20230420185907_community_create_gamification_score_events.rb
+++ b/db/migrate/20230420185907_community_create_gamification_score_events.rb
@@ -2,16 +2,20 @@
 
 class CommunityCreateGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def change
-    create_table :gamification_score_events do |t|
-      t.integer :user_id, null: false
-      t.date :date, null: false
-      t.integer :points, null: false
-      t.text :description, null: true
+    unless table_exists?(:gamification_score_events)
+      create_table :gamification_score_events do |t|
+        t.integer :user_id, null: false
+        t.date :date, null: false
+        t.integer :points, null: false
+        t.text :description, null: true
 
-      t.timestamps
+        t.timestamps
+      end
     end
 
-    add_index :gamification_score_events, %i[user_id date], unique: false
-    add_index :gamification_score_events, %i[date], unique: false
+    unless index_exists?(:gamification_score_events, %i[user_id date])
+      add_index :gamification_score_events, %i[user_id date], unique: false
+    end
+    add_index :gamification_score_events, %i[date], unique: false unless index_exists?(:gamification_score_events, %i[date])
   end
 end

--- a/db/migrate/20250102185908_community_add_period_filter_disabled_to_leaderboards.rb
+++ b/db/migrate/20250102185908_community_add_period_filter_disabled_to_leaderboards.rb
@@ -2,10 +2,12 @@
 
 class CommunityAddPeriodFilterDisabledToLeaderboards < ActiveRecord::Migration[7.2]
   def change
-    add_column :gamification_leaderboards,
-               :period_filter_disabled,
-               :boolean,
-               default: false,
-               null: false
+    unless column_exists?(:gamification_leaderboards, :period_filter_disabled)
+      add_column :gamification_leaderboards,
+                 :period_filter_disabled,
+                 :boolean,
+                 default: false,
+                 null: false
+    end
   end
 end

--- a/db/migrate/20250103120909_community_add_reason_to_gamification_score_events.rb
+++ b/db/migrate/20250103120909_community_add_reason_to_gamification_score_events.rb
@@ -2,6 +2,8 @@
 
 class CommunityAddReasonToGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def up
+    return if column_exists?(:gamification_score_events, :reason)
+
     # 1. Add the column as nullable with a default empty string
     add_column :gamification_score_events, :reason, :string, default: "", null: true
 
@@ -17,6 +19,6 @@ class CommunityAddReasonToGamificationScoreEvents < ActiveRecord::Migration[7.0]
   end
 
   def down
-    remove_column :gamification_score_events, :reason
+    remove_column :gamification_score_events, :reason if column_exists?(:gamification_score_events, :reason)
   end
 end

--- a/db/migrate/20250630080910_community_update_scores_to_cumulative.rb
+++ b/db/migrate/20250630080910_community_update_scores_to_cumulative.rb
@@ -2,7 +2,9 @@
 
 class CommunityUpdateScoresToCumulative < ActiveRecord::Migration[7.0]
   def up
-    remove_index :gamification_scores, [:user_id, :date]
+    return if index_exists?(:gamification_scores, :user_id, unique: true)
+
+    remove_index :gamification_scores, [:user_id, :date] if index_exists?(:gamification_scores, [:user_id, :date])
 
     if column_exists?(:gamification_scores, :created_at)
       execute <<~SQL
@@ -44,7 +46,11 @@ class CommunityUpdateScoresToCumulative < ActiveRecord::Migration[7.0]
   end
 
   def down
-    remove_index :gamification_scores, :user_id
-    add_index :gamification_scores, [:user_id, :date], unique: true
+    if index_exists?(:gamification_scores, :user_id, unique: true)
+      remove_index :gamification_scores, :user_id
+    end
+    unless index_exists?(:gamification_scores, [:user_id, :date])
+      add_index :gamification_scores, [:user_id, :date], unique: true
+    end
   end
 end

--- a/db/migrate/20250701000911_community_add_related_fields_to_gamification_score_events.rb
+++ b/db/migrate/20250701000911_community_add_related_fields_to_gamification_score_events.rb
@@ -1,6 +1,10 @@
 class CommunityAddRelatedFieldsToGamificationScoreEvents < ActiveRecord::Migration[7.0]
   def change
-    add_column :gamification_score_events, :related_id, :text
-    add_column :gamification_score_events, :related_type, :text
+    unless column_exists?(:gamification_score_events, :related_id)
+      add_column :gamification_score_events, :related_id, :text
+    end
+    unless column_exists?(:gamification_score_events, :related_type)
+      add_column :gamification_score_events, :related_type, :text
+    end
   end
 end


### PR DESCRIPTION
## Summary
- make all migrations idempotent by checking for existing tables, columns, and indexes

## Testing
- `bundle exec rake spec` *(fails: could not find rubocop-discourse, activesupport, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687916268adc832c83c448488a2aa734