### PR TITLE
Fix admin plugin route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,11 @@ Discourse::Application.routes.draw do
     get "/leaderboards/:id" => "community_gamification/admin_gamification_leaderboard#show"
   end
 
+  # Alias new plugin route for admin plugin entry
+  get "/admin/plugins/community-gamification" =>
+        "community_gamification/admin_gamification_leaderboard#index",
+      constraints: StaffConstraint.new
+
   get "/admin/plugins/gamification" =>
         "community_gamification/admin_gamification_leaderboard#index",
       :constraints => StaffConstraint.new


### PR DESCRIPTION
## Summary
- expose `/admin/plugins/community-gamification` route for plugin admin page

## Testing
- `bundle install` *(fails: Forbidden)*
- `pnpm install` *(fails: network error)*
- `pnpm exec eslint .` *(fails: network error)*

------
https://chatgpt.com/codex/tasks/task_e_6879764f17ac832cb5d143f9be4c906d