### PR TITLE
Add daily check-in on homepage visit

### DIFF
--- a/app/controllers/community_gamification/check_ins_controller.rb
+++ b/app/controllers/community_gamification/check_ins_controller.rb
@@ -5,39 +5,61 @@ class CommunityGamification::CheckInsController < ApplicationController
   before_action :ensure_logged_in
 
   def create
-    unless SiteSetting.score_day_visited_enabled
-      render json: { points_awarded: false, points: 0 }
+    today = Date.current
+
+    if SiteSetting.score_day_visited_enabled
+      reason = SiteSetting.day_visited_score_reason
+      weekend = today.saturday? || today.sunday?
+      points = if weekend
+        SiteSetting.day_visited_weekend_score_value
+      else
+        SiteSetting.day_visited_score_value
+      end
+      description = weekend ? "주말출석" : "출석"
+
+      existing = CommunityGamification::GamificationScoreEvent.find_by(
+        user_id: current_user.id,
+        date: today,
+        reason: reason,
+      )
+
+      if existing
+        render json: { points_awarded: false, points: 0 }
+      else
+        event = CommunityGamification::GamificationScoreEvent.record!(
+          user_id: current_user.id,
+          date: today,
+          points: points,
+          reason: reason,
+          description: description,
+        )
+
+        render json: { points_awarded: true, points: event.points }
+      end
       return
     end
 
-    today = Date.current
-    reason = SiteSetting.day_visited_score_reason
-    weekend = today.saturday? || today.sunday?
-    points = if weekend
-      SiteSetting.day_visited_weekend_score_value
-    else
-      SiteSetting.day_visited_score_value
-    end
-    description = weekend ? "주말출석" : "출석"
-
-    existing = CommunityGamification::GamificationScoreEvent.find_by(
+    before_count = CommunityGamification::GamificationScoreEvent.where(
       user_id: current_user.id,
       date: today,
-      reason: reason,
-    )
+      reason: CommunityGamification::FirstLoginRewarder::REASON,
+    ).count
 
-    if existing
-      render json: { points_awarded: false, points: 0 }
+    CommunityGamification::FirstLoginRewarder.new(current_user).call
+
+    after_count = CommunityGamification::GamificationScoreEvent.where(
+      user_id: current_user.id,
+      date: today,
+      reason: CommunityGamification::FirstLoginRewarder::REASON,
+    ).count
+
+    awarded = after_count > before_count
+    points = if awarded
+      today.saturday? || today.sunday? ? SiteSetting.day_visited_weekend_score_value : SiteSetting.day_visited_score_value
     else
-      event = CommunityGamification::GamificationScoreEvent.record!(
-        user_id: current_user.id,
-        date: today,
-        points: points,
-        reason: reason,
-        description: description,
-      )
-
-      render json: { points_awarded: true, points: event.points }
+      0
     end
+
+    render json: { points_awarded: awarded, points: points }
   end
 end

--- a/assets/javascripts/initializers/check-in.js
+++ b/assets/javascripts/initializers/check-in.js
@@ -10,18 +10,23 @@ export default {
         return;
       }
 
-      if (!api.container.lookup("site-settings:main").score_day_visited_enabled) {
-        return;
-      }
-
-      ajax("/gamification/check-in.json").then((result) => {
-        if (result.points_awarded) {
-          api.addFlash(
-            I18n.t("gamification.check_in_awarded", { points: result.points }),
-            "success",
-          );
+      const performCheckIn = () => {
+        if (window.location.pathname !== "/") {
+          return;
         }
-      });
+
+        ajax("/gamification/check-in.json").then((result) => {
+          if (result.points_awarded) {
+            api.addFlash(
+              I18n.t("gamification.check_in_awarded", { points: result.points }),
+              "success",
+            );
+          }
+        });
+      };
+
+      performCheckIn();
+      api.onPageChange(performCheckIn);
     });
   },
 };

--- a/spec/requests/check_ins_controller_spec.rb
+++ b/spec/requests/check_ins_controller_spec.rb
@@ -16,9 +16,13 @@ RSpec.describe CommunityGamification::CheckInsController do
     expect(response.parsed_body["points_awarded"]).to eq(false)
   end
 
-  it "does not award points when disabled" do
+  it "awards login points when daily visit disabled" do
     sign_in(user)
     SiteSetting.score_day_visited_enabled = false
+
+    post "/gamification/check-in.json"
+    expect(response.parsed_body["points_awarded"]).to eq(true)
+    expect(CommunityGamification::GamificationScoreEvent.last.reason).to eq("first_login")
 
     post "/gamification/check-in.json"
     expect(response.parsed_body["points_awarded"]).to eq(false)


### PR DESCRIPTION
## Summary
- ensure `/gamification/check-in` works when daily visit score is disabled
- trigger check-in only on the homepage and on page changes
- update tests for the new behaviour

## Testing
- `bundle exec rspec spec/requests/check_ins_controller_spec.rb -fd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687eda810cbc832cb012cb2bce6d22e6