### PR TITLE
Fix check‑in ajax path

### DIFF
--- a/assets/javascripts/initializers/check-in.js
+++ b/assets/javascripts/initializers/check-in.js
@@ -15,7 +15,8 @@ export default {
           return;
         }
 
-        ajax("/community_gamification/check-in.json").then((result) => {
+        // controller route defined in config/routes.rb
+        ajax("/gamification/check-in.json").then((result) => {
           if (result.points_awarded) {
             api.addFlash(
               I18n.t("gamification.check_in_awarded", { points: result.points }),


### PR DESCRIPTION
## Summary
- point check-in JavaScript to the correct endpoint
- add inline comment referencing routes

## Testing
- `bundle exec rake` *(fails: Could not find rubocop-discourse-3.12.1, syntax_tree-6.2.0...)*

------
https://chatgpt.com/codex/tasks/task_e_687eee963c90832c96675cd61e7fc938