### PR TITLE
Add daily login reward callback

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -382,3 +382,11 @@ after_initialize do
     end
   end
 end
+
+after_initialize do
+  Warden::Manager.after_set_user except: :fetch do |user, auth, opts|
+    Rails.cache.fetch("checkin:#{user.id}:#{Date.current}") do
+      CommunityGamification::FirstLoginRewarder.new(user).call
+    end
+  end
+end

--- a/spec/requests/login_check_in_callback_spec.rb
+++ b/spec/requests/login_check_in_callback_spec.rb
@@ -1,0 +1,30 @@
+require "rails_helper"
+
+RSpec.describe "Login check-in via Warden callback" do
+  fab!(:user)
+
+  before { SiteSetting.community_gamification_enabled = true }
+
+  it "awards points only once per day on login" do
+    SiteSetting.score_day_visited_enabled = false
+    SiteSetting.day_visited_score_value = 5
+
+    sign_in(user)
+
+    event_count = CommunityGamification::GamificationScoreEvent.where(
+      user_id: user.id,
+      date: Date.current,
+      reason: CommunityGamification::FirstLoginRewarder::REASON,
+    ).count
+    expect(event_count).to eq(1)
+
+    sign_in(user)
+
+    event_count = CommunityGamification::GamificationScoreEvent.where(
+      user_id: user.id,
+      date: Date.current,
+      reason: CommunityGamification::FirstLoginRewarder::REASON,
+    ).count
+    expect(event_count).to eq(1)
+  end
+end


### PR DESCRIPTION
## Summary
- award login reward on the first login of the day using a Warden callback
- test that the callback only awards points once per day

## Testing
- `bundle exec rake` *(fails: Could not find rubocop-discourse-3.12.1, syntax_tree-6.2.0, activesupport-8.0.2, lint_roller-1.1.0 ...)*

------
https://chatgpt.com/codex/tasks/task_e_687f0fb8d650832c80332cfa983ee3fb