### PR TITLE
Switch check-in to service

### DIFF
--- a/app/controllers/community_gamification/check_ins_controller.rb
+++ b/app/controllers/community_gamification/check_ins_controller.rb
@@ -5,61 +5,7 @@ class CommunityGamification::CheckInsController < ApplicationController
   before_action :ensure_logged_in
 
   def create
-    today = Date.current
-
-    if SiteSetting.score_day_visited_enabled
-      reason = SiteSetting.day_visited_score_reason
-      weekend = today.saturday? || today.sunday?
-      points = if weekend
-        SiteSetting.day_visited_weekend_score_value
-      else
-        SiteSetting.day_visited_score_value
-      end
-      description = weekend ? "주말출석" : "출석"
-
-      existing = CommunityGamification::GamificationScoreEvent.find_by(
-        user_id: current_user.id,
-        date: today,
-        reason: reason,
-      )
-
-      if existing
-        render json: { points_awarded: false, points: 0 }
-      else
-        event = CommunityGamification::GamificationScoreEvent.record!(
-          user_id: current_user.id,
-          date: today,
-          points: points,
-          reason: reason,
-          description: description,
-        )
-
-        render json: { points_awarded: true, points: event.points }
-      end
-      return
-    end
-
-    before_count = CommunityGamification::GamificationScoreEvent.where(
-      user_id: current_user.id,
-      date: today,
-      reason: CommunityGamification::FirstLoginRewarder::REASON,
-    ).count
-
-    CommunityGamification::FirstLoginRewarder.new(current_user).call
-
-    after_count = CommunityGamification::GamificationScoreEvent.where(
-      user_id: current_user.id,
-      date: today,
-      reason: CommunityGamification::FirstLoginRewarder::REASON,
-    ).count
-
-    awarded = after_count > before_count
-    points = if awarded
-      today.saturday? || today.sunday? ? SiteSetting.day_visited_weekend_score_value : SiteSetting.day_visited_score_value
-    else
-      0
-    end
-
-    render json: { points_awarded: awarded, points: points }
+    result = CommunityGamification::CheckInRecorder.new(current_user).call
+    render json: result
   end
 end

--- a/lib/community_gamification/check_in_recorder.rb
+++ b/lib/community_gamification/check_in_recorder.rb
@@ -1,0 +1,69 @@
+module CommunityGamification
+  class CheckInRecorder
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      today = Date.current
+
+      if SiteSetting.score_day_visited_enabled
+        record_day_visit(today)
+      else
+        record_first_login(today)
+      end
+    end
+
+    private
+
+    def record_day_visit(today)
+      reason = SiteSetting.day_visited_score_reason
+      weekend = today.saturday? || today.sunday?
+      points = weekend ? SiteSetting.day_visited_weekend_score_value : SiteSetting.day_visited_score_value
+      description = weekend ? "주말출석" : "출석"
+
+      existing = GamificationScoreEvent.find_by(
+        user_id: @user.id,
+        date: today,
+        reason: reason,
+      )
+
+      if existing
+        { points_awarded: false, points: 0 }
+      else
+        event = GamificationScoreEvent.record!(
+          user_id: @user.id,
+          date: today,
+          points: points,
+          reason: reason,
+          description: description,
+        )
+        { points_awarded: true, points: event.points }
+      end
+    end
+
+    def record_first_login(today)
+      before_count = GamificationScoreEvent.where(
+        user_id: @user.id,
+        date: today,
+        reason: FirstLoginRewarder::REASON,
+      ).count
+
+      FirstLoginRewarder.new(@user).call
+
+      after_count = GamificationScoreEvent.where(
+        user_id: @user.id,
+        date: today,
+        reason: FirstLoginRewarder::REASON,
+      ).count
+
+      awarded = after_count > before_count
+      points = if awarded
+        today.saturday? || today.sunday? ? SiteSetting.day_visited_weekend_score_value : SiteSetting.day_visited_score_value
+      else
+        0
+      end
+      { points_awarded: awarded, points: points }
+    end
+  end
+end

--- a/spec/requests/login_check_in_callback_spec.rb
+++ b/spec/requests/login_check_in_callback_spec.rb
@@ -1,15 +1,15 @@
 require "rails_helper"
 
-RSpec.describe "Login check-in via Warden callback" do
+RSpec.describe "Login check-in via user_seen callback" do
   fab!(:user)
 
   before { SiteSetting.community_gamification_enabled = true }
 
-  it "awards points only once per day on login" do
+  it "awards points only once per day when user is seen" do
     SiteSetting.score_day_visited_enabled = false
     SiteSetting.day_visited_score_value = 5
 
-    sign_in(user)
+    DiscourseEvent.trigger(:user_seen, user)
 
     event_count = CommunityGamification::GamificationScoreEvent.where(
       user_id: user.id,
@@ -18,7 +18,7 @@ RSpec.describe "Login check-in via Warden callback" do
     ).count
     expect(event_count).to eq(1)
 
-    sign_in(user)
+    DiscourseEvent.trigger(:user_seen, user)
 
     event_count = CommunityGamification::GamificationScoreEvent.where(
       user_id: user.id,


### PR DESCRIPTION
## Summary
- encapsulate check-in logic in new `CheckInRecorder`
- use `CheckInRecorder` from controller and `user_seen` event

## Testing
- `bundle exec rspec spec/requests/login_check_in_callback_spec.rb --format doc -fd` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_687f2261b4f8832ca2bcce5e6459b7a5