### PR TITLE
Update leaderboard route

### DIFF
--- a/assets/javascripts/discourse/components/gamification-leaderboard.gjs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.gjs
@@ -105,7 +105,7 @@ export default class GamificationLeaderboard extends Component {
     this.set("loading", true);
 
     return ajax(
-      `/leaderboard/${this.model.leaderboard.id}?page=${this.page}&period=${this.period}`
+      `/point_rank/${this.model.leaderboard.id}?page=${this.page}&period=${this.period}`
     )
       .then((result) => {
         if (result.users.length === 0) {
@@ -122,7 +122,7 @@ export default class GamificationLeaderboard extends Component {
   changePeriod(period) {
     this.set("period", period);
     return ajax(
-      `/leaderboard/${this.model.leaderboard.id}?period=${this.period}`
+      `/point_rank/${this.model.leaderboard.id}?period=${this.period}`
     )
       .then((result) => {
         if (result.users.length === 0) {

--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard.gjs
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard.gjs
@@ -19,8 +19,8 @@ export default class extends Component {
 
     // id is used by discourse-right-sidebar-blocks theme component
     const endpoint = this.args.id
-      ? `/leaderboard/${this.args.id}`
-      : "/leaderboard";
+      ? `/point_rank/${this.args.id}`
+      : "/point_rank";
 
     ajax(endpoint, { data: { user_limit: this.args.count || 10 } }).then(
       (model) => {

--- a/assets/javascripts/discourse/gamification-route-map.js
+++ b/assets/javascripts/discourse/gamification-route-map.js
@@ -1,5 +1,5 @@
 export default function () {
-  this.route("gamificationLeaderboard", { path: "/leaderboard" }, function () {
+  this.route("gamificationLeaderboard", { path: "/point_rank" }, function () {
     this.route("byName", { path: "/:leaderboardId" });
   });
 }

--- a/assets/javascripts/discourse/routes/gamification-leaderboard-by-name.js
+++ b/assets/javascripts/discourse/routes/gamification-leaderboard-by-name.js
@@ -6,7 +6,7 @@ export default class GamificationLeaderboardByName extends DiscourseRoute {
   @service router;
 
   model(params) {
-    return ajax(`/leaderboard/${params.leaderboardId}`)
+    return ajax(`/point_rank/${params.leaderboardId}`)
       .then((response) => {
         return response;
       })

--- a/assets/javascripts/discourse/routes/gamification-leaderboard-index.js
+++ b/assets/javascripts/discourse/routes/gamification-leaderboard-index.js
@@ -6,7 +6,7 @@ export default class GamificationLeaderboardIndex extends DiscourseRoute {
   @service router;
 
   model() {
-    return ajax(`/leaderboard`)
+    return ajax(`/point_rank`)
       .then((response) => {
         return response;
       })

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ CommunityGamification::Engine.routes.draw do
 end
 
 Discourse::Application.routes.draw do
-  mount ::CommunityGamification::Engine, at: "/leaderboard"
+  mount ::CommunityGamification::Engine, at: "/point_rank"
 
   scope "/admin/plugins/community-gamification", constraints: StaffConstraint.new do
     get "/leaderboards" => "community_gamification/admin_gamification_leaderboard#index"

--- a/spec/requests/gamification_leaderboard_controller_spec.rb
+++ b/spec/requests/gamification_leaderboard_controller_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
     it "returns users and their calculated scores" do
       CommunityGamification::LeaderboardCachedView.new(leaderboard).create
 
-      get "/leaderboard/#{leaderboard.id}.json"
+      get "/point_rank/#{leaderboard.id}.json"
       expect(response.status).to eq(200)
 
       data = response.parsed_body
@@ -68,7 +68,7 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
     end
 
     it "returns an in progress message when leaderboard positions are not ready" do
-      expect do get "/leaderboard/#{leaderboard.id}.json" end.to change {
+      expect do get "/point_rank/#{leaderboard.id}.json" end.to change {
         Jobs::GenerateLeaderboardPositions.jobs.size
       }.by(1)
 
@@ -78,7 +78,7 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
 
     it "only returns users and scores for specified date range" do
       CommunityGamification::LeaderboardCachedView.new(leaderboard_2).create
-      get "/leaderboard/#{leaderboard_2.id}.json"
+      get "/point_rank/#{leaderboard_2.id}.json"
 
       expect(response.status).to eq(200)
 
@@ -91,7 +91,7 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
     it "respects the user_limit parameter" do
       CommunityGamification::LeaderboardCachedView.new(leaderboard).create
 
-      get "/leaderboard/#{leaderboard.id}.json?user_limit=1"
+      get "/point_rank/#{leaderboard.id}.json?user_limit=1"
       expect(response.status).to eq(200)
 
       data = response.parsed_body
@@ -107,7 +107,7 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
 
       CommunityGamification::LeaderboardCachedView.new(leaderboard_with_group).create
 
-      get "/leaderboard/#{leaderboard_with_group.id}.json"
+      get "/point_rank/#{leaderboard_with_group.id}.json"
       expect(response.status).to eq(200)
 
       data = response.parsed_body
@@ -123,27 +123,27 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
       )
       CommunityGamification::LeaderboardCachedView.new(leaderboard).create
 
-      get "/leaderboard/#{leaderboard.id}.json"
+      get "/point_rank/#{leaderboard.id}.json"
       data = response.parsed_body
       expect(data["users"].map { |u| u["id"] }).to_not include(staged_user.id, anon_user.id)
     end
 
     it "does not error if visible_to_groups_ids or included_groups_ids are empty" do
       CommunityGamification::LeaderboardCachedView.new(leaderboard).create
-      get "/leaderboard/#{leaderboard.id}.json"
+      get "/point_rank/#{leaderboard.id}.json"
       expect(response.status).to eq(200)
     end
 
     it "errors if visible_to_groups_ids are present and user in not a part of a included group" do
       current_user.groups = []
-      get "/leaderboard/#{leaderboard_with_group.id}.json"
+      get "/point_rank/#{leaderboard_with_group.id}.json"
       expect(response.status).to eq(404)
     end
 
     it "displays leaderboard to users included in group within visible_to_groups_ids" do
       CommunityGamification::LeaderboardCachedView.new(leaderboard_with_group).create
 
-      get "/leaderboard/#{leaderboard_with_group.id}.json"
+      get "/point_rank/#{leaderboard_with_group.id}.json"
       expect(response.status).to eq(200)
     end
 
@@ -152,7 +152,7 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
       CommunityGamification::LeaderboardCachedView.new(leaderboard_with_group).create
 
       sign_in(current_user)
-      get "/leaderboard/#{leaderboard_with_group.id}.json"
+      get "/point_rank/#{leaderboard_with_group.id}.json"
       expect(response.status).to eq(200)
     end
 
@@ -162,13 +162,13 @@ RSpec.describe CommunityGamification::GamificationLeaderboardController do
         leaderboard_with_default_period_set_to_daily,
       ).create
 
-      get "/leaderboard/#{leaderboard.id}.json"
+      get "/point_rank/#{leaderboard.id}.json"
       regular_user_score = response.parsed_body["users"][0]["total_score"]
 
-      get "/leaderboard/#{leaderboard.id}.json?period=daily"
+      get "/point_rank/#{leaderboard.id}.json?period=daily"
       daily_user_score = response.parsed_body["users"][0]["total_score"]
 
-      get "/leaderboard/#{leaderboard_with_default_period_set_to_daily.id}.json"
+      get "/point_rank/#{leaderboard_with_default_period_set_to_daily.id}.json"
       default_user_score = response.parsed_body["users"][0]["total_score"]
 
       expect(default_user_score).to eq(daily_user_score)

--- a/test/javascripts/components/minimal-gamification-leaderboard-test.gjs
+++ b/test/javascripts/components/minimal-gamification-leaderboard-test.gjs
@@ -10,7 +10,7 @@ module(
     setupRenderingTest(hooks);
 
     test("regular leaderboard endpoint", async function (assert) {
-      pretender.get("/leaderboard", () =>
+      pretender.get("/point_rank", () =>
         response({
           leaderboard: "",
           personal: "",
@@ -24,7 +24,7 @@ module(
     });
 
     test("leaderboard by id and with custom user count", async function (assert) {
-      pretender.get("/leaderboard/3", ({ queryParams }) => {
+      pretender.get("/point_rank/3", ({ queryParams }) => {
         assert.strictEqual(queryParams.user_limit, "5");
 
         return response({


### PR DESCRIPTION
## Summary
- change public leaderboard path to `/point_rank`
- update Ember routes and API endpoints
- adjust specs and tests to match new path

## Testing
- `bundle exec rubocop` *(fails: command not found)*
- `pnpm install --frozen-lockfile` *(fails: could not access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68887c975d04832c9ccbe811fc0b1a68