### PR TITLE
Disable leaderboard filter and show user level icons

### DIFF
--- a/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
@@ -21,6 +21,11 @@ export default class GamificationLeaderboardRow extends Component {
         data-user-card={{this.rank.username}}
       >
         {{avatar this.rank imageSize="large"}}
+        {{#if this.rank.gamification_level_info}}
+          <span class="level-icon-small">
+            <img src={{this.rank.gamification_level_info.image_url}} />
+          </span>
+        {{/if}}
         <span class="user__name">
           {{#if this.siteSettings.prioritize_username_in_ux}}
             {{this.rank.username}}

--- a/assets/javascripts/discourse/components/gamification-leaderboard.gjs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.gjs
@@ -59,10 +59,14 @@ export default class GamificationLeaderboard extends Component {
 
   init() {
     super.init(...arguments);
-    const default_leaderboard_period = periodString(
-      this.model.leaderboard.default_period
-    );
-    this.set("period", default_leaderboard_period);
+    if (this.model.leaderboard.period_filter_disabled) {
+      this.set("period", "all");
+    } else {
+      const default_leaderboard_period = periodString(
+        this.model.leaderboard.default_period
+      );
+      this.set("period", default_leaderboard_period);
+    }
   }
 
   @discourseComputed("model.reason")
@@ -155,15 +159,17 @@ export default class GamificationLeaderboard extends Component {
       </div>
 
       <div class="leaderboard__controls">
-        <PeriodChooser
-          @period={{this.period}}
-          @action={{this.changePeriod}}
-          @fullDay={{false}}
-          @options={{hash
-            disabled=this.model.leaderboard.period_filter_disabled
-          }}
-          class="leaderboard__period-chooser"
-        />
+        {{#unless this.model.leaderboard.period_filter_disabled}}
+          <PeriodChooser
+            @period={{this.period}}
+            @action={{this.changePeriod}}
+            @fullDay={{false}}
+            @options={{hash
+              disabled=this.model.leaderboard.period_filter_disabled
+            }}
+            class="leaderboard__period-chooser"
+          />
+        {{/unless}}
         {{#if this.currentUser.staff}}
           <a href="/admin/plugins/gamification" class="leaderboard__settings">
             {{icon "gear"}}

--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard-row.gjs
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard-row.gjs
@@ -29,6 +29,11 @@ export default class MinimalGamificationLeaderboardRow extends Component {
         class="user__avatar clickable"
       >
         {{avatar @rank imageSize="small"}}
+        {{#if @rank.gamification_level_info}}
+          <span class="level-icon-small">
+            <img src={{@rank.gamification_level_info.image_url}} />
+          </span>
+        {{/if}}
 
         {{#if @rank.isCurrentUser}}
           <span class="user__name">{{i18n "gamification.you"}}</span>

--- a/assets/stylesheets/common/gamification-level.scss
+++ b/assets/stylesheets/common/gamification-level.scss
@@ -39,3 +39,9 @@
   padding: 0 5px;
   height: 25px;
 }
+
+.level-icon-small img {
+  width: 24px;
+  height: 24px;
+  margin-right: 0.25rem;
+}


### PR DESCRIPTION
## Summary
- hide period chooser when disabled
- default period to `all` when filter disabled
- show level icons next to leaderboard usernames
- style smaller level icons

## Testing
- `bundle install` *(fails: 403 Forbidden)*
- `bundle exec rubocop --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897f51879c832cb2448e94b6f5a80d