### PR TITLE
Show level icons in leaderboard

### DIFF
--- a/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
@@ -27,6 +27,11 @@ export default class GamificationLeaderboardRow extends Component {
           </span>
         {{/if}}
         <span class="user__name">
+          {{#if this.rank.gamification_level_info}}
+            <span class="level-icon-small">
+              <img src={{this.rank.gamification_level_info.image_url}} />
+            </span>
+          {{/if}}
           {{#if this.siteSettings.prioritize_username_in_ux}}
             {{this.rank.username}}
           {{else}}

--- a/assets/javascripts/discourse/components/gamification-leaderboard.gjs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard.gjs
@@ -208,6 +208,11 @@ export default class GamificationLeaderboard extends Component {
                   </div>
                 </div>
                 <div class="winner__name">
+                  {{#if winner.gamification_level_info}}
+                    <span class="level-icon">
+                      <img src={{winner.gamification_level_info.image_url}} />
+                    </span>
+                  {{/if}}
                   {{#if this.siteSettings.prioritize_username_in_ux}}
                     {{winner.username}}
                   {{else}}
@@ -231,7 +236,14 @@ export default class GamificationLeaderboard extends Component {
           {{#if this.currentUserRanking.user}}
             <div class="user -self">
               <div class="user__rank">{{this.currentUserRanking.position}}</div>
-              <div class="user__name">{{i18n "gamification.you"}}</div>
+              <div class="user__name">
+                {{#if this.currentUserRanking.user.gamification_level_info}}
+                  <span class="level-icon-small">
+                    <img src={{this.currentUserRanking.user.gamification_level_info.image_url}} />
+                  </span>
+                {{/if}}
+                {{i18n "gamification.you"}}
+              </div>
               <div class="user__score">
                 {{#if this.site.mobileView}}
                   {{number this.currentUserRanking.user.total_score}}

--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard-row.gjs
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard-row.gjs
@@ -36,9 +36,21 @@ export default class MinimalGamificationLeaderboardRow extends Component {
         {{/if}}
 
         {{#if @rank.isCurrentUser}}
-          <span class="user__name">{{i18n "gamification.you"}}</span>
+          <span class="user__name">
+            {{#if @rank.gamification_level_info}}
+              <span class="level-icon-small">
+                <img src={{@rank.gamification_level_info.image_url}} />
+              </span>
+            {{/if}}
+            {{i18n "gamification.you"}}
+          </span>
         {{else}}
           <span class="user__name">
+            {{#if @rank.gamification_level_info}}
+              <span class="level-icon-small">
+                <img src={{@rank.gamification_level_info.image_url}} />
+              </span>
+            {{/if}}
             {{#if this.siteSettings.prioritize_username_in_ux}}
               {{@rank.username}}
             {{else}}

--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard.gjs
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard.gjs
@@ -64,7 +64,14 @@ export default class extends Component {
       {{#if this.notTopTen}}
         <div class="user -self">
           <div class="user__rank">{{this.model.personal.position}}</div>
-          <div class="user__name">{{i18n "gamification.you"}}</div>
+          <div class="user__name">
+            {{#if this.model.personal.user.gamification_level_info}}
+              <span class="level-icon-small">
+                <img src={{this.model.personal.user.gamification_level_info.image_url}} />
+              </span>
+            {{/if}}
+            {{i18n "gamification.you"}}
+          </div>
           <div class="user__score">
             {{#if this.site.mobileView}}
               {{number this.model.personal.user.total_score}}


### PR DESCRIPTION
## Summary
- display user level images next to winner names
- show level icon next to the current user's name
- include level icon beside usernames in leaderboard rows and minimal view

## Testing
- `bundle exec rake` *(fails: Could not find rubocop-discourse-3.12.1 ... GemNotFound)*

------
https://chatgpt.com/codex/tasks/task_e_6889913c98ec832c92af7148952b5bca