### PR TITLE
Fix duplicated level icon on leaderboard

### DIFF
--- a/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
+++ b/assets/javascripts/discourse/components/gamification-leaderboard-row.gjs
@@ -27,11 +27,6 @@ export default class GamificationLeaderboardRow extends Component {
           </span>
         {{/if}}
         <span class="user__name">
-          {{#if this.rank.gamification_level_info}}
-            <span class="level-icon-small">
-              <img src={{this.rank.gamification_level_info.image_url}} />
-            </span>
-          {{/if}}
           {{#if this.siteSettings.prioritize_username_in_ux}}
             {{this.rank.username}}
           {{else}}

--- a/assets/javascripts/discourse/components/minimal-gamification-leaderboard-row.gjs
+++ b/assets/javascripts/discourse/components/minimal-gamification-leaderboard-row.gjs
@@ -37,20 +37,10 @@ export default class MinimalGamificationLeaderboardRow extends Component {
 
         {{#if @rank.isCurrentUser}}
           <span class="user__name">
-            {{#if @rank.gamification_level_info}}
-              <span class="level-icon-small">
-                <img src={{@rank.gamification_level_info.image_url}} />
-              </span>
-            {{/if}}
             {{i18n "gamification.you"}}
           </span>
         {{else}}
           <span class="user__name">
-            {{#if @rank.gamification_level_info}}
-              <span class="level-icon-small">
-                <img src={{@rank.gamification_level_info.image_url}} />
-              </span>
-            {{/if}}
             {{#if this.siteSettings.prioritize_username_in_ux}}
               {{@rank.username}}
             {{else}}


### PR DESCRIPTION
## Summary
- remove second level-icon image from leaderboard rows

## Testing
- `bundle exec rake plugin:spec` *(fails: could not find gems)*
- `pnpm install --frozen-lockfile` *(fails: network access needed)*

------
https://chatgpt.com/codex/tasks/task_e_68899ada6944832c83fe2d7983f616f3