### PR TITLE
Add available point tracking to gamification scores

### DIFF
--- a/app/models/community_gamification/gamification_score.rb
+++ b/app/models/community_gamification/gamification_score.rb
@@ -16,10 +16,11 @@ module ::CommunityGamification
 
     def self.adjust_score(user_id:, points:)
       DB.exec(<<~SQL, user_id: user_id, points: points)
-        INSERT INTO gamification_scores (user_id, score, date)
-        VALUES (:user_id, :points, CURRENT_DATE)
+        INSERT INTO gamification_scores (user_id, score, point, date)
+        VALUES (:user_id, :points, :points, CURRENT_DATE)
         ON CONFLICT (user_id) DO UPDATE
-        SET score = gamification_scores.score + EXCLUDED.score;
+        SET score = gamification_scores.score + EXCLUDED.score,
+            point = gamification_scores.point + EXCLUDED.point;
       SQL
 
       LeaderboardCachedView.refresh_all
@@ -31,8 +32,8 @@ module ::CommunityGamification
       DB.exec(<<~SQL, since: since_date)
         DELETE FROM gamification_scores;
 
-        INSERT INTO gamification_scores (user_id, score, date)
-        SELECT user_id, SUM(points) AS score, CURRENT_DATE
+        INSERT INTO gamification_scores (user_id, score, point, date)
+        SELECT user_id, SUM(points) AS score, SUM(points) AS point, CURRENT_DATE
         FROM (
           #{queries}
           UNION ALL
@@ -43,22 +44,24 @@ module ::CommunityGamification
         WHERE user_id IS NOT NULL
         GROUP BY 1
         ON CONFLICT (user_id) DO UPDATE
-        SET score = EXCLUDED.score;
+        SET score = EXCLUDED.score,
+            point = EXCLUDED.point;
       SQL
     end
 
     def self.merge_scores(source_user, target_user)
       DB.exec(<<~SQL, source_id: source_user.id, target_id: target_user.id)
         WITH new_scores AS (
-          SELECT :target_id AS user_id, SUM(score) AS score
+          SELECT :target_id AS user_id, SUM(score) AS score, SUM(point) AS point
           FROM gamification_scores
           WHERE user_id IN (:source_id, :target_id)
           GROUP BY 1
-        ) INSERT INTO gamification_scores (user_id, score, date)
-          SELECT user_id, score AS score, CURRENT_DATE
+        ) INSERT INTO gamification_scores (user_id, score, point, date)
+          SELECT user_id, score AS score, point, CURRENT_DATE
           FROM new_scores
           ON CONFLICT (user_id) DO UPDATE
-          SET score = EXCLUDED.score;
+          SET score = EXCLUDED.score,
+              point = EXCLUDED.point;
       SQL
 
       DB.exec(<<~SQL, source_id: source_user.id)
@@ -77,6 +80,7 @@ end
 #  user_id :integer          not null
 #  date    :date             not null
 #  score   :integer          not null
+#  point   :integer          not null
 #
 # Indexes
 #

--- a/db/migrate/20220314190901_community_create_gamification_score_table.rb
+++ b/db/migrate/20220314190901_community_create_gamification_score_table.rb
@@ -6,6 +6,7 @@ class CommunityCreateGamificationScoreTable < ActiveRecord::Migration[6.1]
         t.integer :user_id, null: false
         t.date :date, null: false
         t.integer :score, null: false
+        t.integer :point, null: false, default: 0
       end
     end
 

--- a/db/migrate/20250630080910_community_update_scores_to_cumulative.rb
+++ b/db/migrate/20250630080910_community_update_scores_to_cumulative.rb
@@ -36,12 +36,12 @@ class CommunityUpdateScoresToCumulative < ActiveRecord::Migration[7.0]
 
     execute <<~SQL
       WITH summed AS (
-        SELECT user_id, SUM(score) AS score
+        SELECT user_id, SUM(score) AS score, SUM(point) AS point
         FROM gamification_scores
         GROUP BY 1
       )
-      INSERT INTO gamification_scores (user_id, score, date)
-      SELECT user_id, score, CURRENT_DATE FROM summed;
+      INSERT INTO gamification_scores (user_id, score, point, date)
+      SELECT user_id, score, point, CURRENT_DATE FROM summed;
     SQL
   end
 

--- a/db/migrate/20250701000912_community_add_point_to_gamification_scores.rb
+++ b/db/migrate/20250701000912_community_add_point_to_gamification_scores.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CommunityAddPointToGamificationScores < ActiveRecord::Migration[7.0]
+  def up
+    add_column :gamification_scores, :point, :integer, null: false, default: 0 unless column_exists?(:gamification_scores, :point)
+    execute("UPDATE gamification_scores SET point = score") if column_exists?(:gamification_scores, :point)
+  end
+
+  def down
+    remove_column :gamification_scores, :point if column_exists?(:gamification_scores, :point)
+  end
+end

--- a/spec/fabricators/gamification_score.rb
+++ b/spec/fabricators/gamification_score.rb
@@ -3,5 +3,6 @@
 Fabricator(:gamification_score, from: ::CommunityGamification::GamificationScore) do
   user_id { Fabricate(:user).id }
   score { 0 }
+  point { |attrs| attrs[:score] }
   date { Date.today }
 end

--- a/spec/services/first_login_rewarder_spec.rb
+++ b/spec/services/first_login_rewarder_spec.rb
@@ -18,11 +18,15 @@ RSpec.describe CommunityGamification::FirstLoginRewarder do
       event = CommunityGamification::GamificationScoreEvent.find_by(user_id: user.id, description: 'first_login')
       expect(event).to be_present
       expect(event.points).to eq(5)
-      expect(CommunityGamification::GamificationScore.find_by(user_id: user.id).score).to eq(5)
+      gamification_score = CommunityGamification::GamificationScore.find_by(user_id: user.id)
+      expect(gamification_score.score).to eq(5)
+      expect(gamification_score.point).to eq(5)
 
       described_class.new(user).call
       expect(CommunityGamification::GamificationScoreEvent.where(user_id: user.id, description: 'first_login').count).to eq(1)
-      expect(CommunityGamification::GamificationScore.find_by(user_id: user.id).score).to eq(5)
+      gamification_score = CommunityGamification::GamificationScore.find_by(user_id: user.id)
+      expect(gamification_score.score).to eq(5)
+      expect(gamification_score.point).to eq(5)
     end
   end
 


### PR DESCRIPTION
## Summary
- add `point` column to gamification scores for available points
- update score calculations and merges to keep `point` in sync with `score`
- cover available points in specs

## Testing
- `bundle exec rake spec` *(fails: Could not find required gems)*
- `bundle install` *(fails: 403 Forbidden while fetching gems)*

------
https://chatgpt.com/codex/tasks/task_e_689d65822584832cbd9e3a8a597da012